### PR TITLE
Fixed syntax bug in the xor challenge

### DIFF
--- a/introduction/xor/challenge/challenge
+++ b/introduction/xor/challenge/challenge
@@ -41,7 +41,7 @@ def xor_maker(plaintext: str, key: str, rounds: int = 3):
 
         ciphertext = new_ciphertext
     
-    print(f"\Encrypted Ciphertext (Hex): {ciphertext.encode().hex()}")
+    print(f"Encrypted Ciphertext (Hex): {ciphertext.encode().hex()}")
     return ciphertext
 
 def xor():


### PR DESCRIPTION
removed a "\\" at the start of a print(f"")