### PR TITLE
do not animate flag reveal for challenge mode

### DIFF
--- a/maths/crt/run
+++ b/maths/crt/run
@@ -194,7 +194,7 @@ class EnhancedCRTTutorial:
         self.console.print(Text("Outstanding! You've mastered the CRT!", style=f"bold {self.colors['accent']}"))
         time.sleep(0.3)
         flag = self.load_flag()
-        self.shuffle_reveal(flag)
+        print(flag)
 
 if __name__=='__main__':
     EnhancedCRTTutorial().run()

--- a/maths/fermat/run
+++ b/maths/fermat/run
@@ -192,7 +192,7 @@ class EnhancedFermatTutorial:
         self.console.print(Text("Exceptional work! You've mastered Fermat's Theorem!", style=f"bold {self.colors['success']}"))
         time.sleep(0.3)
         flag = self.load_flag()
-        self.shuffle_reveal(flag)
+        print(flag)
 
 if __name__=='__main__':
     EnhancedFermatTutorial().run()

--- a/maths/final/run
+++ b/maths/final/run
@@ -199,7 +199,7 @@ class EnhancedRSATutorial:
                                 style=f"bold {self.colors['success']}"))
         time.sleep(0.5)
         flag = self.load_flag()
-        self.shuffle_reveal(flag)
+        print(flag)
 
 if __name__ == "__main__":
     EnhancedRSATutorial().run()

--- a/maths/modularinverse/run
+++ b/maths/modularinverse/run
@@ -173,7 +173,7 @@ class EnhancedInverseTutorial:
         self.console.print(Text("Fantastic! You've mastered modular inverses!", style=f"bold {self.colors['accent']}"))
         time.sleep(0.3)
         flag = self.load_flag()
-        self.shuffle_reveal(flag)
+        print(flag)
 
 if __name__=='__main__':
     EnhancedInverseTutorial().run()


### PR DESCRIPTION
Calling `reveal_flag` after a challenge has been solved (outside the tutorial) results in a lengthy wait time.  This PR simply prints the flag in those instances.